### PR TITLE
boat item code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Metal Boats no longer crash the game when dispensed
+
+### Contributors for this release
+
+- hadean
+
 ## [1.20.1-1.11.2.0] - 2024-01-13
 
 ### Added

--- a/src/main/java/com/mraof/minestuck/entity/item/MetalBoatEntity.java
+++ b/src/main/java/com/mraof/minestuck/entity/item/MetalBoatEntity.java
@@ -1,6 +1,7 @@
 package com.mraof.minestuck.entity.item;
 
 import com.mraof.minestuck.entity.MSEntityTypes;
+import com.mraof.minestuck.item.CustomBoatItem;
 import com.mraof.minestuck.item.MSItems;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -9,10 +10,12 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -145,7 +148,7 @@ public class MetalBoatEntity extends Boat implements IEntityAdditionalSpawnData
 		return NetworkHooks.getEntitySpawningPacket(this);
 	}
 	
-	public enum Type
+	public enum Type implements CustomBoatItem.BoatProvider
 	{
 		IRON(1 / 1.5F, () -> Items.IRON_INGOT, MSItems.IRON_BOAT, new ResourceLocation("minestuck", "textures/entity/iron_boat.png")),
 		GOLD(1.0F, () -> Items.GOLD_INGOT, MSItems.GOLD_BOAT, new ResourceLocation("minestuck", "textures/entity/gold_boat.png"));
@@ -181,6 +184,12 @@ public class MetalBoatEntity extends Boat implements IEntityAdditionalSpawnData
 		public ResourceLocation getBoatTexture()
 		{
 			return boatTexture;
+		}
+		
+		@Override
+		public Entity createBoat(ItemStack stack, Level level, double x, double y, double z)
+		{
+			return new MetalBoatEntity(level, x, y, z, this);
 		}
 	}
 }

--- a/src/main/java/com/mraof/minestuck/item/CustomBoatItem.java
+++ b/src/main/java/com/mraof/minestuck/item/CustomBoatItem.java
@@ -1,6 +1,5 @@
 package com.mraof.minestuck.item;
 
-import com.mraof.minestuck.entity.item.MetalBoatEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.BlockSource;
 import net.minecraft.core.Direction;
@@ -26,12 +25,12 @@ import java.util.function.Predicate;
 public class CustomBoatItem extends Item
 {
 	private static final Predicate<Entity> CAN_COLLIDE_PREDICATE = EntitySelector.NO_SPECTATORS.and(Entity::isPickable);
-	protected final MetalBoatEntity.Type boatType;
+	protected final BoatProvider provider;
 	
-	public CustomBoatItem(MetalBoatEntity.Type boatType, Properties properties)
+	public CustomBoatItem(BoatProvider provider, Properties properties)
 	{
 		super(properties);
-		this.boatType = boatType;
+		this.provider = provider;
 		DispenserBlock.registerBehavior(this, new BehaviorDispenseCustomBoat());
 	}
 	
@@ -55,7 +54,7 @@ public class CustomBoatItem extends Item
 				return InteractionResultHolder.pass(itemstack);
 		}
 		
-		Entity boat = new MetalBoatEntity(level, rayTrace.getLocation().x, rayTrace.getLocation().y, rayTrace.getLocation().z, boatType);
+		Entity boat = provider.createBoat(itemstack, level, rayTrace.getLocation().x, rayTrace.getLocation().y, rayTrace.getLocation().z);
 		boat.setYRot(player.getYRot());
 		
 		if(!level.noCollision(boat, boat.getBoundingBox().inflate(-0.1D)))
@@ -87,11 +86,16 @@ public class CustomBoatItem extends Item
 			if(!level.getBlockState(pos).isAir() || !level.getFluidState(pos.below()).is(FluidTags.WATER))
 				return new DefaultDispenseItemBehavior().dispense(source, stack);
 			
-			Entity boat = new MetalBoatEntity(level, x, y + waterOffset, z, boatType);
+			Entity boat = provider.createBoat(stack, level, x, y + waterOffset, z);
 			boat.setYRot(direction.toYRot());
 			level.addFreshEntity(boat);
 			stack.shrink(1);
 			return stack;
 		}
+	}
+	
+	public interface BoatProvider
+	{
+		Entity createBoat(ItemStack stack, Level level, double x, double y, double z);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/item/CustomBoatItem.java
+++ b/src/main/java/com/mraof/minestuck/item/CustomBoatItem.java
@@ -1,5 +1,6 @@
 package com.mraof.minestuck.item;
 
+import com.mraof.minestuck.entity.item.MetalBoatEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.BlockSource;
 import net.minecraft.core.Direction;
@@ -16,8 +17,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DispenserBlock;
-import net.minecraft.world.level.block.LevelEvent;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
@@ -27,61 +26,49 @@ import java.util.function.Predicate;
 public class CustomBoatItem extends Item
 {
 	private static final Predicate<Entity> CAN_COLLIDE_PREDICATE = EntitySelector.NO_SPECTATORS.and(Entity::isPickable);
-	protected final BoatProvider provider;
+	protected final MetalBoatEntity.Type boatType;
 	
-	public CustomBoatItem(BoatProvider provider, Properties properties)
+	public CustomBoatItem(MetalBoatEntity.Type boatType, Properties properties)
 	{
 		super(properties);
-		this.provider = provider;
+		this.boatType = boatType;
 		DispenserBlock.registerBehavior(this, new BehaviorDispenseCustomBoat());
 	}
 	
 	@Override
-	public InteractionResultHolder<ItemStack> use(Level level, Player playerIn, InteractionHand handIn)
+	public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand)
 	{
 		float partialTicks = 1.0F;
-		ItemStack itemstack = playerIn.getItemInHand(handIn);
-		HitResult rayTrace = getPlayerPOVHitResult(level, playerIn, ClipContext.Fluid.ANY);
+		ItemStack itemstack = player.getItemInHand(hand);
+		HitResult rayTrace = getPlayerPOVHitResult(level, player, ClipContext.Fluid.ANY);
 		
-		if(rayTrace.getType() == HitResult.Type.MISS)
+		if(rayTrace.getType() != HitResult.Type.BLOCK)
 			return InteractionResultHolder.pass(itemstack);
-		else
+		
+		Vec3 lookDirection = player.getViewVector(partialTicks);
+		List<Entity> list = level.getEntities(player, player.getBoundingBox().expandTowards(lookDirection.scale(5.0D)).inflate(1.0D), CAN_COLLIDE_PREDICATE);
+		
+		if(!list.isEmpty())
 		{
-			Vec3 lookDirection = playerIn.getViewVector(partialTicks);
-			List<Entity> list = level.getEntities(playerIn, playerIn.getBoundingBox().expandTowards(lookDirection.scale(5.0D)).inflate(1.0D), CAN_COLLIDE_PREDICATE);
-			
-			if(!list.isEmpty())
-			{
-				Vec3 eyePos = playerIn.getEyePosition(partialTicks);
-				for(Entity entity : list)
-				{
-					AABB axisalignedbb = entity.getBoundingBox().inflate(entity.getPickRadius());
-					
-					if(axisalignedbb.contains(eyePos))
-						return InteractionResultHolder.pass(itemstack);
-				}
-			}
-			
-			if(rayTrace.getType() == HitResult.Type.BLOCK)
-			{
-				Entity boat = provider.createBoat(itemstack, level, rayTrace.getLocation().x, rayTrace.getLocation().y, rayTrace.getLocation().z);
-				boat.setYRot(playerIn.getYRot());
-				
-				if(!level.noCollision(boat, boat.getBoundingBox().inflate(-0.1D)))
-					return InteractionResultHolder.fail(itemstack);
-				
-				if(!level.isClientSide)
-					level.addFreshEntity(boat);
-				
-				if(!playerIn.getAbilities().instabuild)
-					itemstack.shrink(1);
-				
-				playerIn.awardStat(Stats.ITEM_USED.get(this));
-				return InteractionResultHolder.success(itemstack);
-			}
-			
-			return InteractionResultHolder.pass(itemstack);
+			Vec3 eyePos = player.getEyePosition(partialTicks);
+			if(list.stream().anyMatch(entity -> entity.getBoundingBox().inflate(entity.getPickRadius()).contains(eyePos)))
+				return InteractionResultHolder.pass(itemstack);
 		}
+		
+		Entity boat = new MetalBoatEntity(level, rayTrace.getLocation().x, rayTrace.getLocation().y, rayTrace.getLocation().z, boatType);
+		boat.setYRot(player.getYRot());
+		
+		if(!level.noCollision(boat, boat.getBoundingBox().inflate(-0.1D)))
+			return InteractionResultHolder.fail(itemstack);
+		
+		if(!level.isClientSide)
+			level.addFreshEntity(boat);
+		
+		if(!player.getAbilities().instabuild)
+			itemstack.shrink(1);
+		
+		player.awardStat(Stats.ITEM_USED.get(this));
+		return InteractionResultHolder.success(itemstack);
 	}
 	
 	protected class BehaviorDispenseCustomBoat extends DefaultDispenseItemBehavior
@@ -91,36 +78,20 @@ public class CustomBoatItem extends Item
 		{
 			Direction direction = source.getBlockState().getValue(DispenserBlock.FACING);
 			Level level = source.getLevel();
-			double d0 = source.x() + (double)((float)direction.getStepX() * 1.125F);
-			double d1 = source.y() + (double)((float)direction.getStepY() * 1.125F);
-			double d2 = source.z() + (double)((float)direction.getStepZ() * 1.125F);
+			double x = source.x() + (double)((float)direction.getStepX() * 1.125F);
+			double y = source.y() + (double)((float)direction.getStepY() * 1.125F);
+			double z = source.z() + (double)((float)direction.getStepZ() * 1.125F);
 			BlockPos pos = source.getPos().relative(direction);
-			double d3;
+			double waterOffset = level.getFluidState(pos).is(FluidTags.WATER)? 1 : 0;
 			
-			if(level.getFluidState(pos).is(FluidTags.WATER))
-				d3 = 1.0D;
-			else
-			{
-				if (!level.getBlockState(pos).isAir() || !level.getFluidState(pos.below()).is(FluidTags.WATER))
-					return this.dispense(source, stack);
-				
-				d3 = 0.0D;
-			}
-			Entity boat = provider.createBoat(stack, level, d0, d1 + d3, d2);
+			if(!level.getBlockState(pos).isAir() || !level.getFluidState(pos.below()).is(FluidTags.WATER))
+				return new DefaultDispenseItemBehavior().dispense(source, stack);
+			
+			Entity boat = new MetalBoatEntity(level, x, y + waterOffset, z, boatType);
 			boat.setYRot(direction.toYRot());
 			level.addFreshEntity(boat);
 			stack.shrink(1);
 			return stack;
 		}
-		@Override
-		protected void playSound(BlockSource source)
-		{
-			source.getLevel().levelEvent(LevelEvent.SOUND_DISPENSER_DISPENSE, source.getPos(), 0);
-		}
-	}
-	
-	public interface BoatProvider
-	{
-		Entity createBoat(ItemStack stack, Level level, double x, double y, double z);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/item/MSItems.java
+++ b/src/main/java/com/mraof/minestuck/item/MSItems.java
@@ -660,8 +660,8 @@ public class MSItems
 	
 	//Incredibly Useful Items
 	public static final RegistryObject<Item> URANIUM_POWERED_STICK = REGISTER.register("uranium_powered_stick", () -> new Item(new Item.Properties().stacksTo(1)));
-	public static final RegistryObject<Item> IRON_BOAT = REGISTER.register("iron_boat", () -> new CustomBoatItem((stack, world, x, y, z) -> new MetalBoatEntity(world, x, y, z, MetalBoatEntity.Type.IRON), new Item.Properties().stacksTo(1)));
-	public static final RegistryObject<Item> GOLD_BOAT = REGISTER.register("gold_boat", () -> new CustomBoatItem((stack, world, x, y, z) -> new MetalBoatEntity(world, x, y, z, MetalBoatEntity.Type.GOLD), new Item.Properties().stacksTo(1)));
+	public static final RegistryObject<Item> IRON_BOAT = REGISTER.register("iron_boat", () -> new CustomBoatItem(MetalBoatEntity.Type.IRON, new Item.Properties().stacksTo(1)));
+	public static final RegistryObject<Item> GOLD_BOAT = REGISTER.register("gold_boat", () -> new CustomBoatItem(MetalBoatEntity.Type.GOLD, new Item.Properties().stacksTo(1)));
 	public static final RegistryObject<Item> COCOA_WART = REGISTER.register("cocoa_wart", () -> new Item(new Item.Properties()));
 	public static final RegistryObject<MultiblockItem> HORSE_CLOCK = REGISTER.register("horse_clock", () -> new MultiblockItem(MSBlocks.HORSE_CLOCK, new Item.Properties()));
 	


### PR DESCRIPTION
While working on the dispenser behaviors, I noticed that metal boats caused a stack overflow when trying to dispense them. This fixes that, cleans up and de-nests the code a bit, and removes the `BoatProvider` interface by using metal boat types directly.