### PR TITLE
Fixing crouching for block pressure plates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Metal Boats no longer crash the game when dispensed
+- Block Pressure Plates no longer cycle power states endlessly when players are crouched on them
 
 ### Contributors for this release
 
-- hadean
+- hadean, Dweblenod
 
 ## [1.20.1-1.11.2.0] - 2024-01-13
 


### PR DESCRIPTION
Block pressure plates are supposed to only stay depressed (provide redstone power) if there is a block above it or a player who is not crouching. The bug occurring was that it would keep losing and gaining power when a player was crouching on it instead of just not getting powered at all