### PR TITLE
Fix fall damage for minestuck fluids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Metal Boats no longer crash the game when dispensed
 - Block Pressure Plates no longer cycle power states endlessly when players are crouched on them
 - Fixed underling texture layer that on hurt wasn't tinted red with the rest of the underling
+- Fixed fall damage for minestuck fluids
 
 ### Contributors for this release
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,8 @@ minecraft {
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_forge_version}"
 
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+
 	// http://dvs1.progwml6.com/files/maven
     compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${mc_jei_version}")
     compileOnly fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${mc_jei_version}")
@@ -137,6 +139,14 @@ dependencies {
 
 sourceSets.main.resources {
     srcDir 'src/main/generated/resources'
+}
+
+mixin {
+    add sourceSets.main, 'mixins.minestuck.refmap.json'
+    config 'mixins.minestuck.json'
+
+    debug.verbose = true
+    debug.export = true
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/com/mraof/minestuck/fluid/MSFluidType.java
+++ b/src/main/java/com/mraof/minestuck/fluid/MSFluidType.java
@@ -12,6 +12,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -139,5 +140,19 @@ public class MSFluidType extends FluidType
 	public static final class LastFluidTickData
 	{
 		private final Map<MSFluidType, Long> lastTickMap = new HashMap<>();
+	}
+	
+	/**
+	 * Called to apply fall distance resetting for fluids added by us.
+	 */
+	public static void handleExtraFallReset(LivingEntity entity)
+	{
+		if(entity.fallDistance <= 0 || !entity.isInFluidType())
+			return;
+		
+		entity.fallDistance *= MSFluids.TYPE_REGISTER.getEntries().stream().map(RegistryObject::get)
+				.filter(entity::isInFluidType)
+				.map(entity::getFluidFallDistanceModifier)
+				.min(Float::compare).orElse(1F);
 	}
 }

--- a/src/main/java/com/mraof/minestuck/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/mraof/minestuck/mixin/LivingEntityMixin.java
@@ -1,0 +1,25 @@
+package com.mraof.minestuck.mixin;
+
+import com.mraof.minestuck.fluid.MSFluidType;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin
+{
+	/**
+	 * After entity movement, and before applying fall damage, vanilla does a fluid check to reset fall distance if the entity moved into water.
+	 * However, the forge patch for resetting fall distance when in mod fluids does not cover this specific circumstance, which is why this mixin exists.
+	 * Because the call to {@code Entity#updateInWaterStateAndDoWaterCurrentPushing()} also updates the fluid height of all touched fluids after movement,
+	 * this function is injected immediately after to be able to use these updated fluid heights ourselves.
+	 * This mixin will not be needed once a fix to fall distance resetting exists in forge/neoforge.
+	 */
+	@Inject(method = "checkFallDamage", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;updateInWaterStateAndDoWaterCurrentPushing()V", ordinal = 0, shift = At.Shift.AFTER))
+	protected void onCheckFallDamage(CallbackInfo ci)
+	{
+		MSFluidType.handleExtraFallReset((LivingEntity) (Object) this);
+	}
+}

--- a/src/main/resources/mixins.minestuck.json
+++ b/src/main/resources/mixins.minestuck.json
@@ -1,0 +1,5 @@
+{
+  "package": "com.mraof.minestuck.mixin",
+  "refmap": "mixins.minestuck.refmap.json",
+  "mixins": [ "LivingEntityMixin" ]
+}


### PR DESCRIPTION
Adds a mixin injection to apply fall distance resetting from minestuck fluids at the appropriate time. I have tested it in-dev, but I have not tested it outside yet. That has to be done too to make sure that this is correctly set up with remapping/obfuscation in mind.
Note: with the mixin additions on the gradle side of things, people need to regenerate their runs with this change.