### PR TITLE
Fix advanced color select GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Block Pressure Plates no longer cycle power states endlessly when players are crouched on them
 - Fixed underling texture layer that on hurt wasn't tinted red with the rest of the underling
 - Fluids no longer break gates and return nodes
+- Advanced color selection screen no longer tints buttons
 
 ### Contributors for this release
 
-- hadean, Dweblenod, kirderf1
+- hadean, Dweblenod, kirderf1, glubtier
 
 ## [1.20.1-1.11.2.0] - 2024-01-13
 

--- a/src/main/java/com/mraof/minestuck/client/gui/ColorSelectorScreen.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/ColorSelectorScreen.java
@@ -166,6 +166,7 @@ public class ColorSelectorScreen extends Screen
 			// spirograph color preview
 			RenderSystem.setShaderColor((float)redSlider.getValue()/255F, (float)greenSlider.getValue()/255, (float)blueSlider.getValue()/255, 0.5F);
 			guiGraphics.blit(guiBackground, xOffset+106, yOffset+57, 47, 47, guiWidth, 20, 64, 64, 256, 256);
+			
 		} else
 		{
 			for(ColorSelector canonColor : canonColors)
@@ -177,6 +178,8 @@ public class ColorSelectorScreen extends Screen
 			}
 		}
 		
+		//resets shader color to avoid tinting the whole gui
+		RenderSystem.setShaderColor(1, 1, 1, 1);
 		super.render(guiGraphics, mouseX, mouseY, partialTicks);
 		
 		if(tab==Tab.Canon)


### PR DESCRIPTION
Fix issue of menu buttons in advanced color select GUI being tinted by the selected color by setting the shader back to white after color select.