### PR TITLE
Imp dungeon code cleanup

### DIFF
--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -281,7 +281,7 @@ public final class ImpDungeonPieces
 			super(MSStructurePieces.IMP_STRAIGHT_CORRIDOR.get(), 0, makeGridBoundingBox(3, 0, 0, 4, 5, 10, pos, coordBaseMode));
 			setOrientation(coordBaseMode);
 			
-			light = true;//rand.nextFloat() < 0.1F;
+			light = rand.nextFloat() < 0.4F;
 			if(light)
 				lightPos = (byte) rand.nextInt(4);
 		}

--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -151,11 +151,9 @@ public class ImpDungeonPieces
 		if(ctxt.rand.nextDouble() >= (1.4 - index*0.1))
 			if(ctxt.rand.nextDouble() < 1/3D)
 			{
-				ctxt.builder.addPiece(genRoom(facing, pos, xIndex, zIndex, ctxt));
+				genRoom(facing, pos, xIndex, zIndex, ctxt);
 				return true;
 			} else return false;
-		
-		StructurePiece piece;
 		
 		int corridors = ctxt.corridors;
 		double i = ctxt.rand.nextDouble();
@@ -166,12 +164,12 @@ public class ImpDungeonPieces
 			var corridor = new CrossCorridor(facing, pos, ctxt.rand);
 			
 			ctxt.compoGen[xIndex][zIndex] = corridor;
+			ctxt.builder.addPiece(corridor);
 			corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
 			
-			piece = corridor;
 		} else if(i < 0.96 - corridors*0.06)	//Any room
 		{
-			piece = genRoom(facing, pos, xIndex, zIndex, ctxt);
+			genRoom(facing, pos, xIndex, zIndex, ctxt);
 		} else	//Straight or corner corridor
 		{
 			ctxt.corridors -= 1;
@@ -180,9 +178,8 @@ public class ImpDungeonPieces
 				TurnCorridor corridor = TurnCorridor.create(facing, pos, ctxt.rand);
 				
 				ctxt.compoGen[xIndex][zIndex] = corridor;
+				ctxt.builder.addPiece(corridor);
 				corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
-				
-				piece = corridor;
 			} else
 			{	//Corridor
 				i = ctxt.rand.nextFloat();
@@ -191,47 +188,45 @@ public class ImpDungeonPieces
 					SpawnerCorridor corridor = new SpawnerCorridor(facing, pos, ctxt.rand);
 					
 					ctxt.compoGen[xIndex][zIndex] = corridor;
+					ctxt.builder.addPiece(corridor);
 					corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
 					
-					piece = corridor;
 				} else if (i < 0.3 && !ctxt.generatedOgreRoom)
 				{
+					ctxt.generatedOgreRoom = true;
+					
 					OgreCorridor corridor = new OgreCorridor(facing, pos, ctxt.rand);
 					
 					ctxt.compoGen[xIndex][zIndex] = corridor;
-					ctxt.generatedOgreRoom = true;
+					ctxt.builder.addPiece(corridor);
 					corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
 					
-					piece = corridor;
 				}
 				else if (i < 0.4)
 				{
 					LargeSpawnerCorridor corridor = new LargeSpawnerCorridor(facing, pos, ctxt.rand);
 					
 					ctxt.compoGen[xIndex][zIndex] = corridor;
+					ctxt.builder.addPiece(corridor);
 					corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
-					
-					piece = corridor;
 				}
 				else
 				{
 					StraightCorridor corridor = new StraightCorridor(facing, pos, ctxt.rand);
 					
 					ctxt.compoGen[xIndex][zIndex] = corridor;
+					ctxt.builder.addPiece(corridor);
 					corridor.generateAdjacentPieces(pos, xIndex, zIndex, index, ctxt);
-					
-					piece = corridor;
 				}
 			}
 		}
 		
 		ctxt.corridors = corridors;
-		ctxt.builder.addPiece(piece);
 		
 		return true;
 	}
 	
-	protected static StructurePiece genRoom(Direction facing, BlockPos pos, int xIndex, int zIndex, StructureContext ctxt)
+	protected static void genRoom(Direction facing, BlockPos pos, int xIndex, int zIndex, StructureContext ctxt)
 	{
 		float i = ctxt.rand.nextFloat();
 		if(i < 0.2 || !ctxt.generatedReturn)
@@ -241,24 +236,24 @@ public class ImpDungeonPieces
 			{
 				var room = new ReturnRoom(facing, pos);
 				ctxt.compoGen[xIndex][zIndex] = room;
-				return room;
+				ctxt.builder.addPiece(room);
 			} else
 			{
 				var room = new ReturnRoomAlt(facing, pos);
 				ctxt.compoGen[xIndex][zIndex] = room;
-				return room;
+				ctxt.builder.addPiece(room);
 			}
 		}
 		else if(i < 0.5)
 		{
 			BookcaseRoom room = new BookcaseRoom(facing, pos, ctxt.rand);
 			ctxt.compoGen[xIndex][zIndex] = room;
-			return room;
+			ctxt.builder.addPiece(room);
 		} else
 		{
 			SpawnerRoom room = new SpawnerRoom(facing, pos, ctxt.rand);
 			ctxt.compoGen[xIndex][zIndex] = room;
-			return room;
+			ctxt.builder.addPiece(room);
 		}
 	}
 	

--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -173,7 +173,7 @@ public final class ImpDungeonPieces
 		if(ctxt.rand.nextDouble() >= (1.4 - generationDepth*0.1))
 		{
 			if(ctxt.rand.nextDouble() < 1/3D)
-				return Optional.of(pickRoom(direction, pos, ctxt));
+				return Optional.of(pickRoom(pos, direction, ctxt));
 			else
 				return Optional.empty();
 		}
@@ -185,45 +185,50 @@ public final class ImpDungeonPieces
 			return Optional.of(new CrossCorridor(direction, pos, ctxt.rand));
 		} else if(i < 0.96 - ctxt.corridors*0.06)	//Any room
 		{
-			return Optional.of(pickRoom(direction, pos, ctxt));
+			return Optional.of(pickRoom(pos, direction, ctxt));
 		} else	//Straight or corner corridor
 		{
 			ctxt.corridors -= 1;
-			if(ctxt.rand.nextBoolean())
-				return Optional.of(TurnCorridor.create(direction, pos, ctxt.rand));
-			else
-			{	//Corridor
-				i = ctxt.rand.nextFloat();
-				if(i < 0.2)
-					return Optional.of(new SpawnerCorridor(direction, pos, ctxt.rand));
-				else if (i < 0.3 && !ctxt.generatedOgreRoom)
-				{
-					ctxt.generatedOgreRoom = true;
-					return Optional.of(new OgreCorridor(direction, pos, ctxt.rand));
-				}
-				else if (i < 0.4)
-					return Optional.of(new LargeSpawnerCorridor(direction, pos, ctxt.rand));
-				else
-					return Optional.of(new StraightCorridor(direction, pos, ctxt.rand));
-			}
+			return Optional.of(pickCorridor(pos, direction, ctxt));
 		}
 	}
 	
-	private static StructurePiece pickRoom(Direction facing, BlockPos pos, StructureContext ctxt)
+	private static StructurePiece pickCorridor(BlockPos pos, Direction direction, StructureContext ctxt)
+	{
+		if(ctxt.rand.nextBoolean())
+			return TurnCorridor.create(direction, pos, ctxt.rand);
+		else
+		{	//Corridor
+			double i = ctxt.rand.nextFloat();
+			if(i < 0.2)
+				return new SpawnerCorridor(direction, pos, ctxt.rand);
+			else if (i < 0.3 && !ctxt.generatedOgreRoom)
+			{
+				ctxt.generatedOgreRoom = true;
+				return new OgreCorridor(direction, pos, ctxt.rand);
+			}
+			else if (i < 0.4)
+				return new LargeSpawnerCorridor(direction, pos, ctxt.rand);
+			else
+				return new StraightCorridor(direction, pos, ctxt.rand);
+		}
+	}
+	
+	private static StructurePiece pickRoom(BlockPos pos, Direction direction, StructureContext ctxt)
 	{
 		float i = ctxt.rand.nextFloat();
 		if(!ctxt.generatedReturn || i < 0.2)
 		{
 			ctxt.generatedReturn = true;
 			if(ctxt.rand.nextBoolean())
-				return new ReturnRoom(facing, pos);
+				return new ReturnRoom(direction, pos);
 			else
-				return new ReturnRoomAlt(facing, pos);
+				return new ReturnRoomAlt(direction, pos);
 		}
 		else if(i < 0.5)
-			return new BookcaseRoom(facing, pos, ctxt.rand);
+			return new BookcaseRoom(direction, pos, ctxt.rand);
 		else
-			return new SpawnerRoom(facing, pos, ctxt.rand);
+			return new SpawnerRoom(direction, pos, ctxt.rand);
 	}
 	
 	public static class StructureContext

--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -86,12 +86,12 @@ public final class ImpDungeonPieces
 			Direction orientation = Objects.requireNonNull(getOrientation());
 			if(rand.nextBoolean())
 			{
-				isFrontBlocked = !generatePartInDirection(6, 6, orientation, 0, ctxt);
-				isBackBlocked = !generatePartInDirection(6, 6, orientation.getOpposite(), 0, ctxt);
+				isFrontBlocked = !generatePartInDirection(0, 0, orientation, 0, ctxt);
+				isBackBlocked = !generatePartInDirection(0, 0, orientation.getOpposite(), 0, ctxt);
 			} else
 			{
-				isBackBlocked = !generatePartInDirection(6, 6, orientation.getOpposite(), 0, ctxt);
-				isFrontBlocked = !generatePartInDirection(6, 6, orientation, 0, ctxt);
+				isBackBlocked = !generatePartInDirection(0, 0, orientation.getOpposite(), 0, ctxt);
+				isFrontBlocked = !generatePartInDirection(0, 0, orientation, 0, ctxt);
 			}
 		}
 		
@@ -145,7 +145,7 @@ public final class ImpDungeonPieces
 	
 	static boolean generatePartAt(int xIndex, int zIndex, Direction direction, int generationDepth, StructureContext ctxt)
 	{
-		if(xIndex < 0 || 13 <= xIndex || zIndex < 0 || 13 <= zIndex)
+		if(Math.abs(xIndex) > 6 || Math.abs(zIndex) > 6)
 			return false;
 		
 		if(ctxt.findPieceInGridSlot(xIndex, zIndex) instanceof ConnectablePiece piece)
@@ -237,7 +237,7 @@ public final class ImpDungeonPieces
 		
 		public StructureContext(BlockPos centerPos, StructurePieceAccessor builder, RandomSource rand)
 		{
-			this.zeroPos = centerPos.offset(-60, 0, -60);
+			this.zeroPos = centerPos;
 			this.builder = builder;
 			this.rand = rand;
 		}

--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -79,7 +79,7 @@ public final class ImpDungeonPieces
 		@Override
 		public void addChildren(StructurePiece piece, StructurePieceAccessor builder, RandomSource rand)
 		{
-			BlockPos compoPos = new BlockPos(boundingBox.minX() + (boundingBox.getXSpan()/2 - 1), boundingBox.minY(), boundingBox.minZ() + (boundingBox.getZSpan()/2 - 1));
+			BlockPos compoPos = new BlockPos(boundingBox.minX() + (boundingBox.getXSpan() / 2 - 1), boundingBox.minY(), boundingBox.minZ() + (boundingBox.getZSpan() / 2 - 1));
 			
 			StructureContext ctxt = new StructureContext(compoPos, builder, rand);
 			
@@ -99,18 +99,18 @@ public final class ImpDungeonPieces
 		public void postProcess(WorldGenLevel level, StructureManager manager, ChunkGenerator chunkGeneratorIn, RandomSource randomIn, BoundingBox structureBoundingBoxIn, ChunkPos chunkPosIn, BlockPos pos)
 		{
 			StructureBlockRegistry blocks = StructureBlockRegistry.getOrDefault(chunkGeneratorIn);
-
+			
 			BlockState wallBlock = blocks.getBlockState("structure_primary");
 			BlockState wallDecor = blocks.getBlockState("structure_primary_decorative");
 			BlockState floorBlock = blocks.getBlockState("structure_secondary");
 			BlockState floorDecor = blocks.getBlockState("structure_secondary_decorative");
 			BlockState fluid = blocks.getBlockState("fall_fluid");
-
+			
 			generateBox(level, structureBoundingBoxIn, 1, 0, 4, 4, 0, 6, floorBlock, floorBlock, false);
 			generateAirBox(level, structureBoundingBoxIn, 1, 1, 4, 4, 4, 6);
 			generateBox(level, structureBoundingBoxIn, 2, 0, 5, 3, 0, 5, fluid, fluid, false);
 			generateBox(level, structureBoundingBoxIn, 2, -1, 5, 3, -1, 5, floorDecor, floorDecor, false);
-
+			
 			generateBox(level, structureBoundingBoxIn, 0, 0, 3, 0, 5, 7, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 5, 0, 3, 5, 5, 7, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 1, 4, 3, 4, 5, 3, wallBlock, wallBlock, false);
@@ -119,7 +119,7 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 1, 0, 7, 1, 3, 7, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 4, 0, 3, 4, 3, 3, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 4, 0, 7, 4, 3, 7, wallDecor, wallDecor, false);
-
+			
 			generateBox(level, structureBoundingBoxIn, 2, 0, 0, 3, 0, 3, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 2, 0, 7, 3, 0, 9, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 2, 4, 0, 3, 4, 2, wallBlock, wallBlock, false);
@@ -130,7 +130,7 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 4, 1, 8, 4, 4, 9, wallBlock, wallBlock, false);
 			generateAirBox(level, structureBoundingBoxIn, 2, 1, 0, 3, 3, 3);
 			generateAirBox(level, structureBoundingBoxIn, 2, 1, 7, 3, 3, 9);
-
+			
 			if(isFrontBlocked)
 				generateBox(level, structureBoundingBoxIn, 2, 1, 9, 3, 3, 9, wallBlock, wallBlock, false);
 			if(isBackBlocked)
@@ -170,23 +170,23 @@ public final class ImpDungeonPieces
 	
 	private static Optional<StructurePiece> nextPiece(BlockPos pos, Direction direction, int generationDepth, StructureContext ctxt)
 	{
-		if(ctxt.rand.nextDouble() >= (1.4 - generationDepth*0.1))
+		if(ctxt.rand.nextDouble() >= (1.4 - generationDepth * 0.1))
 		{
-			if(ctxt.rand.nextDouble() < 1/3D)
+			if(ctxt.rand.nextDouble() < 1 / 3D)
 				return Optional.of(pickRoom(pos, direction, ctxt));
 			else
 				return Optional.empty();
 		}
 		
 		double i = ctxt.rand.nextDouble();
-		if(i < 1.2 - ctxt.corridors*0.12)	//Cross corridor
+		if(i < 1.2 - ctxt.corridors * 0.12)    //Cross corridor
 		{
 			ctxt.corridors += 3;
 			return Optional.of(new CrossCorridor(direction, pos, ctxt.rand));
-		} else if(i < 0.96 - ctxt.corridors*0.06)	//Any room
+		} else if(i < 0.96 - ctxt.corridors * 0.06)    //Any room
 		{
 			return Optional.of(pickRoom(pos, direction, ctxt));
-		} else	//Straight or corner corridor
+		} else    //Straight or corner corridor
 		{
 			ctxt.corridors -= 1;
 			return Optional.of(pickCorridor(pos, direction, ctxt));
@@ -198,16 +198,15 @@ public final class ImpDungeonPieces
 		if(ctxt.rand.nextBoolean())
 			return TurnCorridor.create(direction, pos, ctxt.rand);
 		else
-		{	//Corridor
+		{    //Corridor
 			double i = ctxt.rand.nextFloat();
 			if(i < 0.2)
 				return new SpawnerCorridor(direction, pos, ctxt.rand);
-			else if (i < 0.3 && !ctxt.generatedOgreRoom)
+			else if(i < 0.3 && !ctxt.generatedOgreRoom)
 			{
 				ctxt.generatedOgreRoom = true;
 				return new OgreCorridor(direction, pos, ctxt.rand);
-			}
-			else if (i < 0.4)
+			} else if(i < 0.4)
 				return new LargeSpawnerCorridor(direction, pos, ctxt.rand);
 			else
 				return new StraightCorridor(direction, pos, ctxt.rand);
@@ -224,8 +223,7 @@ public final class ImpDungeonPieces
 				return new ReturnRoom(direction, pos);
 			else
 				return new ReturnRoomAlt(direction, pos);
-		}
-		else if(i < 0.5)
+		} else if(i < 0.5)
 			return new BookcaseRoom(direction, pos, ctxt.rand);
 		else
 			return new SpawnerRoom(direction, pos, ctxt.rand);
@@ -249,7 +247,7 @@ public final class ImpDungeonPieces
 		
 		BlockPos centerPosForGridSlot(int xIndex, int zIndex)
 		{
-			return this.zeroPos.offset(10*xIndex, 0, 10*zIndex);
+			return this.zeroPos.offset(10 * xIndex, 0, 10 * zIndex);
 		}
 		
 		@Nullable
@@ -320,28 +318,29 @@ public final class ImpDungeonPieces
 		public void postProcess(WorldGenLevel level, StructureManager manager, ChunkGenerator chunkGeneratorIn, RandomSource randomIn, BoundingBox structureBoundingBoxIn, ChunkPos chunkPosIn, BlockPos pos)
 		{
 			StructureBlockRegistry blocks = StructureBlockRegistry.getOrDefault(chunkGeneratorIn);
-
+			
 			BlockState wallBlock = blocks.getBlockState("structure_primary");
 			BlockState floorBlock = blocks.getBlockState("structure_secondary");
-
+			
 			generateBox(level, structureBoundingBoxIn, 1, 0, 0, 2, 0, 9, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 1, 4, 0, 2, 4, 9, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 0, 0, 0, 0, 4, 9, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 3, 0, 0, 3, 4, 9, wallBlock, wallBlock, false);
 			generateAirBox(level, structureBoundingBoxIn, 1, 1, 0, 2, 3, 9);
-
+			
 			if(isFrontBlocked)
 				generateBox(level, structureBoundingBoxIn, 1, 1, 9, 2, 3, 9, wallBlock, wallBlock, false);
-
+			
 			if(light)
 			{
 				BlockState torch = blocks.getBlockState("wall_torch");
-				if(lightPos/2 == 0)
-					placeBlock(level, torch.setValue(WallTorchBlock.FACING, Direction.WEST), 2, 2, 4 + lightPos%2, structureBoundingBoxIn);
-				else placeBlock(level, torch.setValue(WallTorchBlock.FACING, Direction.EAST), 1, 2, 4 + lightPos%2, structureBoundingBoxIn);
+				if(lightPos / 2 == 0)
+					placeBlock(level, torch.setValue(WallTorchBlock.FACING, Direction.WEST), 2, 2, 4 + lightPos % 2, structureBoundingBoxIn);
+				else
+					placeBlock(level, torch.setValue(WallTorchBlock.FACING, Direction.EAST), 1, 2, 4 + lightPos % 2, structureBoundingBoxIn);
 			}
 		}
-
+		
 		@Override
 		public boolean connectFrom(Direction facing)
 		{
@@ -409,21 +408,21 @@ public final class ImpDungeonPieces
 				isLeftBlocked = false;
 			return true;
 		}
-
+		
 		@Override
 		public void postProcess(WorldGenLevel level, StructureManager manager, ChunkGenerator chunkGeneratorIn, RandomSource randomIn, BoundingBox structureBoundingBoxIn, ChunkPos chunkPosIn, BlockPos pos)
 		{
-
+			
 			StructureBlockRegistry blocks = StructureBlockRegistry.getOrDefault(chunkGeneratorIn);
-
+			
 			BlockState wallBlock = blocks.getBlockState("structure_primary");
 			BlockState wallDecor = blocks.getBlockState("structure_primary_decorative");
 			BlockState floorBlock = blocks.getBlockState("structure_secondary");
-
+			
 			generateBox(level, structureBoundingBoxIn, 4, 0, 0, 5, 0, 9, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 0, 0, 4, 3, 0, 5, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 6, 0, 4, 9, 0, 5, floorBlock, floorBlock, false);
-
+			
 			generateBox(level, structureBoundingBoxIn, 3, 0, 0, 3, 4, 3, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 6, 0, 0, 6, 4, 3, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 3, 0, 6, 3, 4, 9, wallBlock, wallBlock, false);
@@ -432,12 +431,12 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 0, 0, 6, 2, 4, 6, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 7, 0, 3, 9, 4, 3, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 7, 0, 6, 9, 4, 6, wallBlock, wallBlock, false);
-
+			
 			generateAirBox(level, structureBoundingBoxIn, 4, 1, 0, 5, 3, 9);
 			generateAirBox(level, structureBoundingBoxIn, 0, 1, 4, 3, 3, 5);
 			generateAirBox(level, structureBoundingBoxIn, 6, 1, 4, 9, 3, 5);
 			generateAirBox(level, structureBoundingBoxIn, 4, 4, 4, 5, 4, 5);
-
+			
 			generateBox(level, structureBoundingBoxIn, 4, 4, 0, 5, 4, 2, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 4, 4, 3, 5, 4, 3, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 4, 4, 7, 5, 4, 9, wallBlock, wallBlock, false);
@@ -446,16 +445,16 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 3, 4, 4, 3, 4, 5, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 7, 4, 4, 9, 4, 5, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 6, 4, 4, 6, 4, 5, wallDecor, wallDecor, false);
-
+			
 			generateBox(level, structureBoundingBoxIn, 3, 5, 3, 6, 5, 6, wallBlock, wallBlock, false);
-
+			
 			if(isRightBlocked)
 				generateBox(level, structureBoundingBoxIn, 0, 1, 4, 0, 3, 5, wallBlock, wallBlock, false);
 			if(isFrontBlocked)
 				generateBox(level, structureBoundingBoxIn, 4, 1, 9, 5, 3, 9, wallBlock, wallBlock, false);
 			if(isLeftBlocked)
 				generateBox(level, structureBoundingBoxIn, 9, 1, 4, 9, 3, 5, wallBlock, wallBlock, false);
-
+			
 			if(light)
 			{
 				BlockState lightBlock = blocks.getBlockState("light_block");
@@ -525,16 +524,16 @@ public final class ImpDungeonPieces
 			else return false;
 			return true;
 		}
-
+		
 		@Override
 		public void postProcess(WorldGenLevel level, StructureManager manager, ChunkGenerator chunkGeneratorIn, RandomSource randomIn, BoundingBox structureBoundingBoxIn, ChunkPos chunkPosIn, BlockPos pos)
 		{
-
+			
 			StructureBlockRegistry blocks = StructureBlockRegistry.getOrDefault(chunkGeneratorIn);
-
+			
 			BlockState wallBlock = blocks.getBlockState("structure_primary");
 			BlockState floorBlock = blocks.getBlockState("structure_secondary");
-
+			
 			generateBox(level, structureBoundingBoxIn, 4, 0, 0, 5, 0, 5, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 0, 0, 4, 3, 0, 5, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 6, 0, 0, 6, 4, 6, wallBlock, wallBlock, false);
@@ -545,12 +544,12 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 0, 4, 4, 3, 4, 5, wallBlock, wallBlock, false);
 			generateAirBox(level, structureBoundingBoxIn, 4, 1, 0, 5, 3, 5);
 			generateAirBox(level, structureBoundingBoxIn, 0, 1, 4, 3, 3, 5);
-
+			
 			if(isBackBlocked)
 				generateBox(level, structureBoundingBoxIn, 4, 1, 0, 5, 3, 0, wallBlock, wallBlock, false);
 			if(isRightBlocked)
 				generateBox(level, structureBoundingBoxIn, 0, 1, 4, 0, 3, 5, wallBlock, wallBlock, false);
-
+			
 			if(light)
 			{
 				BlockState torch = blocks.getBlockState("wall_torch");
@@ -583,25 +582,25 @@ public final class ImpDungeonPieces
 		{
 			return getOrientation().getOpposite().equals(facing);
 		}
-
+		
 		@Override
 		public void postProcess(WorldGenLevel level, StructureManager manager, ChunkGenerator chunkGeneratorIn, RandomSource randomIn, BoundingBox structureBoundingBoxIn, ChunkPos chunkPosIn, BlockPos pos)
 		{
 			StructureBlockRegistry blocks = StructureBlockRegistry.getOrDefault(chunkGeneratorIn);
-
+			
 			BlockState wallBlock = blocks.getBlockState("structure_primary");
 			BlockState wallDecor = blocks.getBlockState("structure_primary_decorative");
 			BlockState floorBlock = blocks.getBlockState("structure_secondary");
 			BlockState floorDecor = blocks.getBlockState("structure_secondary_decorative");
 			BlockState light = blocks.getBlockState("light_block");
-
+			
 			generateBox(level, structureBoundingBoxIn, 2, 0, 0, 3, 0, 2, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 1, 0, 3, 4, 0, 6, floorBlock, floorBlock, false);
 			generateBox(level, structureBoundingBoxIn, 2, 0, 4, 3, 0, 5, floorDecor, floorDecor, false);
 			generateAirBox(level, structureBoundingBoxIn, 2, 1, 0, 3, 3, 2);
 			generateAirBox(level, structureBoundingBoxIn, 1, 1, 3, 4, 4, 6);
 			generateAirBox(level, structureBoundingBoxIn, 2, 5, 4, 3, 9, 5);
-
+			
 			generateBox(level, structureBoundingBoxIn, 1, 0, 0, 1, 4, 2, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 4, 0, 0, 4, 4, 2, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 0, 0, 2, 0, 5, 7, wallBlock, wallBlock, false);
@@ -612,13 +611,13 @@ public final class ImpDungeonPieces
 			generateBox(level, structureBoundingBoxIn, 0, 3, 4, 0, 3, 5, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 5, 3, 4, 5, 3, 5, wallDecor, wallDecor, false);
 			generateBox(level, structureBoundingBoxIn, 2, 3, 7, 3, 3, 7, wallDecor, wallDecor, false);
-
+			
 			generateBox(level, structureBoundingBoxIn, 1, 5, 3, 4, 10, 3, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 1, 5, 6, 4, 10, 6, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 1, 5, 4, 1, 10, 5, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 4, 5, 4, 4, 10, 5, wallBlock, wallBlock, false);
 			generateBox(level, structureBoundingBoxIn, 2, 10, 4, 3, 10, 5, light, light, false);
-
+			
 			placeReturnNode(level, structureBoundingBoxIn, 2, 1, 4);
 		}
 	}
@@ -929,7 +928,7 @@ public final class ImpDungeonPieces
 		protected void addAdditionalSaveData(StructurePieceSerializationContext context, CompoundTag tagCompound)
 		{
 			tagCompound.putBoolean("bl0", isBackBlocked);
-			tagCompound.putBoolean("bl1",isFrontBlocked);
+			tagCompound.putBoolean("bl1", isFrontBlocked);
 			tagCompound.putBoolean("sp1", spawner1);
 			tagCompound.putBoolean("sp2", spawner2);
 			tagCompound.putBoolean("ch", chestPos);
@@ -1106,7 +1105,7 @@ public final class ImpDungeonPieces
 		{
 			BlockPos pos = new BlockPos(getWorldX(xPos, zPos), getWorldY(yPos), getWorldZ(xPos, zPos));
 			OgreEntity ogre = MSEntityTypes.OGRE.get().create(level.getLevel());
-			ogre.moveTo(pos.getX(), pos.getY(), pos.getZ(), rand.nextFloat()*360F, 0);
+			ogre.moveTo(pos.getX(), pos.getY(), pos.getZ(), rand.nextFloat() * 360F, 0);
 			ogre.finalizeSpawn(level, null, MobSpawnType.STRUCTURE, null, null);
 			ogre.restrictTo(pos, 2);
 			level.addFreshEntity(ogre);
@@ -1237,7 +1236,7 @@ public final class ImpDungeonPieces
 				generateBox(level, structureBoundingBoxIn, 4, 0, 0, 5, 3, 0, wallBlock, wallBlock, false);
 			if(isFrontBlocked)
 				generateBox(level, structureBoundingBoxIn, 4, 0, 9, 5, 3, 9, wallBlock, wallBlock, false);
-		}	
+		}
 	}
 	
 	private static EntityType<?> getTypeForSpawners()
@@ -1258,12 +1257,13 @@ public final class ImpDungeonPieces
 		int y = centerPos.getY();
 		
 		return switch(orientation)
-				{
-					case SOUTH -> new BoundingBox(startX + minX, y + minY, startZ + minZ, startX + maxX, y + maxY, startZ + maxZ);
-					case NORTH -> new BoundingBox(endX - maxX, y + minY, endZ - maxZ, endX - minX, y + maxY, endZ - minZ);
-					case EAST -> new BoundingBox(startX + minZ, y + minY, endZ - maxX, startX + maxZ, y + maxY, endZ - minX);
-					case WEST -> new BoundingBox(endX - maxZ, y + minY, startZ + minX, endX - minZ, y + maxY, startZ + maxX);
-					default -> throw new IllegalArgumentException("Invalid orientation");
-				};
+		{
+			case SOUTH ->
+					new BoundingBox(startX + minX, y + minY, startZ + minZ, startX + maxX, y + maxY, startZ + maxZ);
+			case NORTH -> new BoundingBox(endX - maxX, y + minY, endZ - maxZ, endX - minX, y + maxY, endZ - minZ);
+			case EAST -> new BoundingBox(startX + minZ, y + minY, endZ - maxX, startX + maxZ, y + maxY, endZ - minX);
+			case WEST -> new BoundingBox(endX - maxZ, y + minY, startZ + minX, endX - minZ, y + maxY, startZ + maxX);
+			default -> throw new IllegalArgumentException("Invalid orientation");
+		};
 	}
 }

--- a/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/structure/ImpDungeonPieces.java
@@ -84,16 +84,14 @@ public final class ImpDungeonPieces
 			StructureContext ctxt = new StructureContext(compoPos, builder, rand);
 			
 			Direction orientation = Objects.requireNonNull(getOrientation());
-			int xOffset = orientation.getStepX();
-			int zOffset = orientation.getStepZ();
 			if(rand.nextBoolean())
 			{
-				isFrontBlocked = !generatePart(ctxt, 6 + xOffset, 6 + zOffset, orientation, 0);
-				isBackBlocked = !generatePart(ctxt, 6 - xOffset, 6 - zOffset, orientation.getOpposite(), 0);
+				isFrontBlocked = !generatePartInDirection(6, 6, orientation, 0, ctxt);
+				isBackBlocked = !generatePartInDirection(6, 6, orientation.getOpposite(), 0, ctxt);
 			} else
 			{
-				isBackBlocked = !generatePart(ctxt, 6 - xOffset, 6 - zOffset, orientation.getOpposite(), 0);
-				isFrontBlocked = !generatePart(ctxt, 6 + xOffset, 6 + zOffset, orientation, 0);
+				isBackBlocked = !generatePartInDirection(6, 6, orientation.getOpposite(), 0, ctxt);
+				isFrontBlocked = !generatePartInDirection(6, 6, orientation, 0, ctxt);
 			}
 		}
 		
@@ -140,7 +138,12 @@ public final class ImpDungeonPieces
 		}
 	}
 	
-	static boolean generatePart(StructureContext ctxt, int xIndex, int zIndex, Direction direction, int generationDepth)
+	static boolean generatePartInDirection(int xIndex, int zIndex, Direction direction, int generationDepth, StructureContext ctxt)
+	{
+		return generatePartAt(xIndex + direction.getStepX(), zIndex + direction.getStepZ(), direction, generationDepth, ctxt);
+	}
+	
+	static boolean generatePartAt(int xIndex, int zIndex, Direction direction, int generationDepth, StructureContext ctxt)
 	{
 		if(xIndex < 0 || 13 <= xIndex || zIndex < 0 || 13 <= zIndex)
 			return false;
@@ -157,7 +160,7 @@ public final class ImpDungeonPieces
 			ctxt.builder.addPiece(piece);
 			if(piece instanceof ConnectablePiece connectablePiece)
 				connectablePiece.generateAdjacentPieces(
-						(genDirection, depthIncrement) -> generatePart(ctxt, xIndex + genDirection.getStepX(), zIndex + genDirection.getStepZ(), genDirection, generationDepth + depthIncrement), ctxt.rand);
+						(genDirection, depthIncrement) -> generatePartInDirection(xIndex, zIndex, genDirection, generationDepth + depthIncrement, ctxt), ctxt.rand);
 		});
 		
 		ctxt.corridors = corridors;


### PR DESCRIPTION
Cleaned up the code for imp dungeon pieces, with a focus on simplifying the generation/placement of structure pieces.

I have not pushed this as far as to produce a tool/abstraction immediately usable by other structures. But the code is in a better state to be a) more easily imitated by other structures, and b) easier to add new piece types to imp dungeons.

I briefly considered transforming the piece selection from code-oriented to something a little more data-oriented, as such a system could be more readily useful for other structures. But due to the dynamic nature of the selection making this a little less straightforward, I decided to leave it for now.

It may still be interesting to try and use structure templates for some imp dungeon pieces as a guiding example for future structures. The same applies for some consort village buildings.

I have been paying attention to keep backwards-compatibility with partially-generated dungeons.