### PR TITLE
Update github actions and tweak workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,4 +37,4 @@ jobs:
       timeout-minutes: 5
       run: ./gradlew :runData
     - name: Detect Changes
-      uses: NathanielHill/fail-if-changes@master
+      uses: NathanielHill/fail-if-changes@9e6ed6bb0543551728592d8114cfaa1dcd9155a6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,26 +18,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v2
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
     - name: Gradle Build
       timeout-minutes: 20
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: build
+      run: ./gradlew build
     - name: Data Generation
       timeout-minutes: 5
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: :runData
+      run: ./gradlew :runData
     - name: Detect Changes
       id: changes
       uses: ch4rl3x/has-changes-action@3058353091eb04bf2c56876af42fd5a286b41faa

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,11 +37,4 @@ jobs:
       timeout-minutes: 5
       run: ./gradlew :runData
     - name: Detect Changes
-      id: changes
-      uses: ch4rl3x/has-changes-action@3058353091eb04bf2c56876af42fd5a286b41faa
-    - name: Did runData create changes?
-      if: steps.changes.outputs.changed == 1
-      run: |
-        echo "Files were changed after running runData. Make sure to run runData and commit changes!"
-        git status --porcelain
-        exit 1
+      uses: NathanielHill/fail-if-changes@master

--- a/.github/workflows/gradle_ci.yml
+++ b/.github/workflows/gradle_ci.yml
@@ -11,18 +11,16 @@ permissions:
   contents: read
 
 jobs:
-  build-and-rundata:
+  validate-and-build:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
-
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
-
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v2
     - name: Setup Gradle
@@ -30,8 +28,27 @@ jobs:
     - name: Gradle Build
       timeout-minutes: 20
       run: ./gradlew build
-    - name: Data Generation
-      timeout-minutes: 5
-      run: ./gradlew :runData
-    - name: Detect Changes
-      uses: NathanielHill/fail-if-changes@9e6ed6bb0543551728592d8114cfaa1dcd9155a6
+
+  check-datagen:
+    needs: validate-and-build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: true
+        # Meant to be sped up by cached gradle stuff from the validate-and-build job,
+        # but the cache is only written to when that job is run on the default branch.
+        # If the next step is slow, rerun this action on the default branch to recreate the cache.
+      - name: Run Data Generation
+        timeout-minutes: 20
+        run: ./gradlew :runData
+      - name: Detect Changes
+        uses: NathanielHill/fail-if-changes@9e6ed6bb0543551728592d8114cfaa1dcd9155a6

--- a/.github/workflows/gradle_ci.yml
+++ b/.github/workflows/gradle_ci.yml
@@ -6,9 +6,6 @@ on:
       - '1.20.1'
       - 'upcoming-content'
   pull_request:
-    branches: 
-      - '1.20.1'
-      - 'upcoming-content'
 
 permissions:
   contents: read

--- a/.github/workflows/gradle_ci.yml
+++ b/.github/workflows/gradle_ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Gradle CI
 
 on:
   push:
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-and-rundata:
     runs-on: ubuntu-latest
 
     steps:

--- a/src/main/generated/resources/assets/minestuck/lang/en_us.json
+++ b/src/main/generated/resources/assets/minestuck/lang/en_us.json
@@ -2135,6 +2135,7 @@
   "minestuck.entry.teleport_failed": "Entry failed. Unable to teleport you!",
   "minestuck.entry.wrong_dimension": "Entry not permitted from this dimension",
   "minestuck.entry.wrong_dimension_reentry": "You may not re-enter from this dimension",
+  "minestuck.free": "Free!",
   "minestuck.gate_destroyed": "The destination gate seems to have been destroyed.",
   "minestuck.gate_missing_land": "The land this gate leads to does not exist yet!",
   "minestuck.grist_cache": "Grist Cache",

--- a/src/main/generated/resources/assets/minestuck/lang/en_us.json
+++ b/src/main/generated/resources/assets/minestuck/lang/en_us.json
@@ -2135,7 +2135,6 @@
   "minestuck.entry.teleport_failed": "Entry failed. Unable to teleport you!",
   "minestuck.entry.wrong_dimension": "Entry not permitted from this dimension",
   "minestuck.entry.wrong_dimension_reentry": "You may not re-enter from this dimension",
-  "minestuck.free": "Free!",
   "minestuck.gate_destroyed": "The destination gate seems to have been destroyed.",
   "minestuck.gate_missing_land": "The land this gate leads to does not exist yet!",
   "minestuck.grist_cache": "Grist Cache",


### PR DESCRIPTION
Updates the actions used for our automated test of build and runData.
Also does some smaller tweaks to the workflow:
- Rename some parts
- Let it run for any PR, not just for PRs targeting `1.20.1` or `upcoming-content`
- Put the data generation test in its own job