### PR TITLE
Fix save format for effect in area effect block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Minestuck fences will now connect with vanilla fences appropriately
 - All walls will now connect with each other properly
 - Fixed name typos for some chess castle blocks
+- Area effect blocks now save their effect as a string id instead of an int id
 
 ### Removed
 

--- a/src/main/java/com/mraof/minestuck/blockentity/redstone/AreaEffectBlockEntity.java
+++ b/src/main/java/com/mraof/minestuck/blockentity/redstone/AreaEffectBlockEntity.java
@@ -8,9 +8,11 @@ import com.mraof.minestuck.util.MSRotationUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
@@ -19,6 +21,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -148,7 +151,11 @@ public class AreaEffectBlockEntity extends BlockEntity
 	{
 		super.load(compound);
 		
-		MobEffect effectRead = MobEffect.byId(compound.getInt("effect"));
+		MobEffect effectRead;
+		if(compound.contains("effect", Tag.TAG_STRING))
+			effectRead = ForgeRegistries.MOB_EFFECTS.getValue(new ResourceLocation(compound.getString("effect")));
+		else	// backwards-compatibility with Minestuck 1.20.1-1.11.2.1 and earlier
+			effectRead = MobEffect.byId(compound.getInt("effect"));
 		if(effectRead != null)
 			effect = effectRead;
 		
@@ -170,7 +177,7 @@ public class AreaEffectBlockEntity extends BlockEntity
 	{
 		super.saveAdditional(compound);
 		
-		compound.putInt("effect", MobEffect.getId(getEffect()));
+		compound.putString("effect", String.valueOf(ForgeRegistries.MOB_EFFECTS.getKey(this.getEffect())));
 		compound.putInt("effectAmplifier", effectAmplifier);
 		
 		compound.putInt("minAreaOffsetX", minAreaOffset.getX());


### PR DESCRIPTION
The registry int ids are not necessarily consistent between play sessions or save files, which makes it a bad idea to use it for serialization (with the potential exception of network serialization).

The area effect block was doing this with its effect, which is bad for both save files and structure templates. This pr changes this to use the string id instead, while keeping backwards-compatibility.