### PR TITLE
Land Terrain tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Oil Buckets no longer cost 8 Tar and 8 Shale, now cost 16 Shale
 - Renamed Oil to Shale Oil
 - Pumord is now alchemized with Pumice Stone instead of any regular Stone
+- Minor change to land terrain height
 
 ### Fixed
 

--- a/src/main/java/com/mraof/minestuck/world/gen/LandGenSettings.java
+++ b/src/main/java/com/mraof/minestuck/world/gen/LandGenSettings.java
@@ -41,7 +41,7 @@ public final class LandGenSettings
 	public float roughThreshold = 0.0F;
 	
 	public float oceanOffset = -0.12F;
-	public float inlandOffset = 0.15F;
+	public float inlandOffset = 0.12F;
 	public float inlandAngle = 0.2F;
 	
 	public float oceanFactor = 6;


### PR DESCRIPTION
I felt that the coastal area tended to be a bit steep. This lowers the inland starting height, bringing it closer to the ocean height.

Example difference:
![2024-04-07_18 03 55](https://github.com/lunar-sway/minestuck/assets/5451660/1cb1bfc0-f613-4ad0-8a06-26f5b707138a)
