### PR TITLE
Fixing runData CI issue

### DIFF
--- a/.github/workflows/gradle_ci.yml
+++ b/.github/workflows/gradle_ci.yml
@@ -49,6 +49,6 @@ jobs:
         # If the next step is slow, rerun this action on the default branch to recreate the cache.
       - name: Run Data Generation
         timeout-minutes: 20
-        run: ./gradlew :runData
+        run: ./gradlew :runData -x downloadAssets
       - name: Detect Changes
         uses: NathanielHill/fail-if-changes@9e6ed6bb0543551728592d8114cfaa1dcd9155a6


### PR DESCRIPTION
In recent times, the `check-datagen` CI job has occasionally been failing on the `downloadAssets` task when running `runData`.

As I believe most (and hopefully all) of these minecraft assets aren't actually needed for datagen, disabling the task may be a viable solution.