### PR TITLE
CommandWithFlags Trigger

### DIFF
--- a/src/main/java/com/mraof/minestuck/entity/dialogue/Triggers.java
+++ b/src/main/java/com/mraof/minestuck/entity/dialogue/Triggers.java
@@ -19,6 +19,7 @@ public final class Triggers
 		REGISTER.register("set_player_dialogue", () -> Trigger.SetPlayerDialogue.CODEC);
 		REGISTER.register("open_consort_merchant_gui", () -> Trigger.OpenConsortMerchantGui.CODEC);
 		REGISTER.register("command", () -> Trigger.Command.CODEC);
+		REGISTER.register("command_with_flags", () -> Trigger.CommandWithFlags.CODEC);
 		REGISTER.register("take_item", () -> Trigger.TakeItem.CODEC);
 		REGISTER.register("take_matched_item", () -> Trigger.TakeMatchedItem.CODEC);
 		REGISTER.register("give_item", () -> Trigger.GiveItem.CODEC);


### PR DESCRIPTION
A stretch goal for 4/13 (can take lower priority)! Its just useful in situations where more than one set of flags can result in a mess for command usage.

Below is an example of usage, a modified version of mushroom_pizza. A command is triggered when the last response option is taken. It starts off as "execute as @s in [flag0] run tp ~[flag1] ~ ~". [flag0] corresponds to command.0.minecraft:overworld and [flag1] corresponds to command.1.500. 

- If neither flag is fulfilled, the command runs as "execute as @s in  run tp ~ ~ ~".
- If the first flag is fulfilled, the command runs as "execute as @s in minecraft:overworld run tp ~ ~ ~"
- If the second flag is fulfilled, the command runs as "execute as @s in  run tp ~500 ~ ~"
- If both flags are fulfilled, the command runs as "execute as @s in minecraft:overworld run tp ~500 ~ ~"

```json
{
  "node": {
    "message": "minestuck.dialogue.consort.mushroom_pizza.start",
    "responses": [
      {
        "message": "set dimension flag",
        "next_dialogue": {
          "id": "minestuck:consort/mushroom_pizza/on",
          "player_message": "minestuck.dialogue.consort.mushroom_pizza.start.on.reply",
          "set_as_entrypoint": false
        },
        "triggers": [
          {
            "type": "minestuck:set_flag",
            "flag": "command.0.minecraft:overworld",
            "player_specific": true
          }
        ]
      },
      {
        "message": "set coord flag",
        "triggers": [
          {
            "type": "minestuck:set_flag",
            "flag": "command.1.500",
            "player_specific": true
          }
        ]
      },
      {
        "message": "minestuck.dialogue.consort.mushroom_pizza.start.off",
        "next_dialogue": {
          "id": "minestuck:consort/mushroom_pizza/off",
          "player_message": "minestuck.dialogue.consort.mushroom_pizza.start.off.reply",
          "set_as_entrypoint": false
        },
        "triggers": [
          {
            "type": "minestuck:command_with_flags",
            "command": "execute as @s in [flag0] run tp ~[flag1] ~ ~",
            "flag_amount": 2
          }
        ]
      }
    ]
  }
}
```