### PR TITLE
Fix issue with /sburbconnection

### DIFF
--- a/src/main/java/com/mraof/minestuck/command/SburbPredefineCommand.java
+++ b/src/main/java/com/mraof/minestuck/command/SburbPredefineCommand.java
@@ -84,9 +84,10 @@ public class SburbPredefineCommand
 	private static int define(CommandSourceStack source, ServerPlayer player, Title title, TerrainLandType terrainLand, TitleLandType titleLand) throws CommandSyntaxException
 	{
 		CommandSourceStack silentSource = source.withSuppressedOutput();
-		setTitle(silentSource, player, title);
-		setTitleLand(silentSource, player, titleLand);
-		setTerrainLand(silentSource, player, terrainLand);
+		PredefineData predefineData = getPredefineData(player);
+		predefineData.predefineTitle(title);
+		predefineData.predefineTitleLand(titleLand, silentSource);
+		predefineData.predefineTerrainLand(terrainLand, silentSource);
 		source.sendSuccess(() -> Component.translatable(DEFINE, player.getDisplayName()), true);
 		return 1;
 	}

--- a/src/main/java/com/mraof/minestuck/skaianet/SburbConnections.java
+++ b/src/main/java/com/mraof/minestuck/skaianet/SburbConnections.java
@@ -351,15 +351,15 @@ public final class SburbConnections
 	
 	public void unlinkClientPlayer(PlayerIdentifier clientPlayer)
 	{
-		if(!primaryClientToServerMap.containsKey(clientPlayer))
-			throw new IllegalStateException();
-		Optional<PlayerIdentifier> oldServerPlayer = primaryClientToServerMap.get(clientPlayer);
+		this.getActiveConnection(clientPlayer).ifPresent(this::closeConnection);
 		
+		if(!primaryClientToServerMap.containsKey(clientPlayer))
+			return;
+		Optional<PlayerIdentifier> oldServerPlayer = primaryClientToServerMap.get(clientPlayer);
 		if(oldServerPlayer.isEmpty())
 			return;
 		
 		LOGGER.debug("Disconnecting server {} from client {}", oldServerPlayer.get(), clientPlayer);
-		this.getActiveConnection(clientPlayer).ifPresent(this::closeConnection);
 		primaryClientToServerMap.put(clientPlayer, Optional.empty());
 		
 		skaianetData.sessionHandler.onDisconnect(clientPlayer, oldServerPlayer.get());

--- a/src/main/java/com/mraof/minestuck/skaianet/SkaianetTests.java
+++ b/src/main/java/com/mraof/minestuck/skaianet/SkaianetTests.java
@@ -134,4 +134,22 @@ public final class SkaianetTests
 					&& session == sessions.getOrCreateSession(server), "Session changed after disconnecting");
 		});
 	}
+	
+	@GameTest(timeoutTicks = 0, template = "empty_gametest")
+	public static void redundantCalls(GameTestHelper helper)
+	{
+		helper.succeedIf(() -> {
+			SkaianetData skaianetData = SkaianetData.newInstanceForGameTest(false, helper);
+			SburbConnections connections = skaianetData.connections;
+			
+			PlayerIdentifier client = IdentifierHandler.createNewFakeIdentifier(),
+					server = IdentifierHandler.createNewFakeIdentifier();
+			
+			connections.unlinkClientPlayer(client);
+			connections.unlinkServerPlayer(client);
+			
+			connections.setPrimaryConnection(client, server);
+			connections.setPrimaryConnection(client, server);
+		});
+	}
 }


### PR DESCRIPTION
`sburbConnections.unlinkClientPlayer()` previously threw an exception when there were no paired server player to unlink.
This prevented it from being called redundantly, while it was also being used in a redundant manner by `/sburbconnection`.

This lets `unlinkClientPlayer()` be called redundantly, and also adds a test for this.