### PR TITLE
Fixed Area Effect and Summoner Blocks crashing the game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@
 /src/main/generated/resources/.cache/
 /.metadata
 /logs/
-java_pid29320.hprof

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /src/main/generated/resources/.cache/
 /.metadata
 /logs/
+java_pid29320.hprof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Many organic blocks are now compostable
 - Many wood-based blocks can now be used as fuel
 - Cruxite ore textures tweaked
+- Localized potion name for the status message that appears when right-clicking an Area Effect Block with a potion
+- Localized entity type for the status message that appears when right-clicking a Summoner Block with a Spawn Egg
 
 ### Fixed
 - The Umbral Infiltrator no longer jitters when thrown by a void player
@@ -30,7 +32,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Lotus Flowers no longer push entities inside of them away
 - Ogres and Basilisks no longer slide around when idling
 - Cruxite button now uses raw cruxite instead of cruxite block, which resolves a conflict with storage block breakdown
-
+- Fixed right-clicking on an Area Effect Block with a Potion not properly updating its settings
+- Fixed right-clicking on a Summoner Block with a Spawn Egg not properly updating its settings
 
 ### Contributors for this release
 

--- a/src/main/generated/resources/assets/minestuck/lang/en_us.json
+++ b/src/main/generated/resources/assets/minestuck/lang/en_us.json
@@ -71,7 +71,7 @@
   "block.minestuck.apple_cake": "Apple Cake",
   "block.minestuck.area_effect_block": "Area Effect Block",
   "block.minestuck.area_effect_block.additional_info": "- Can be toggled to apply the effect only to players\n- Can be permanently disabled\n- Area of effect changes when rotated\n- UI only accessible in creative mode\n- Right clicking with a potion bottle in creative mode sets it to that potion effect",
-  "block.minestuck.area_effect_block.effect_change_message": "Effect type changed to %s with the amplification strength %s.",
+  "block.minestuck.area_effect_block.effect_change_message": "Effect type changed to %s",
   "block.minestuck.area_effect_block.tooltip": "Applies a potion effect to entities within a specified area when powered.",
   "block.minestuck.attached_strawberry_stem": "Strawberry Stem",
   "block.minestuck.black_chess_brick_slab": "Black Chess Brick Slab",

--- a/src/main/java/com/mraof/minestuck/block/redstone/AreaEffectBlock.java
+++ b/src/main/java/com/mraof/minestuck/block/redstone/AreaEffectBlock.java
@@ -108,8 +108,9 @@ public class AreaEffectBlock extends HorizontalDirectionalBlock implements Entit
 		{
 			be.setEffect(firstEffect.getEffect(), firstEffect.getAmplifier());
 			
-			player.displayClientMessage(Component.translatable(getDescriptionId() + "." + EFFECT_CHANGE_MESSAGE,
-					BuiltInRegistries.MOB_EFFECT.getKey(firstEffect.getEffect()), firstEffect.getAmplifier()), true);
+			player.displayClientMessage(Component.translatable(getDescriptionId() + "." + EFFECT_CHANGE_MESSAGE, Component.translatable(
+					"potion.withAmplifier", firstEffect.getEffect().getDisplayName(),
+					Component.translatable("potion.potency." + firstEffect.getAmplifier()))), true);
 			level.playSound(null, pos, SoundEvents.UI_BUTTON_CLICK.value(), SoundSource.BLOCKS, 0.5F, 1F);
 		}
 	}

--- a/src/main/java/com/mraof/minestuck/block/redstone/SummonerBlock.java
+++ b/src/main/java/com/mraof/minestuck/block/redstone/SummonerBlock.java
@@ -59,8 +59,7 @@ public class SummonerBlock extends Block implements EntityBlock
 		{
 			if(!level.isClientSide)
 			{
-				summoner.setSummonedEntity(eggItem.getType(stackIn.getTag()));
-				player.displayClientMessage(Component.translatable(SUMMON_TYPE_CHANGE, BuiltInRegistries.ENTITY_TYPE.getKey(eggItem.getType(stackIn.getTag()))), true);
+				summoner.setSummonedEntity(eggItem.getType(stackIn.getTag()));player.displayClientMessage(Component.translatable(SUMMON_TYPE_CHANGE, eggItem.getType(stackIn.getTag()).getDescription()), true);
 			}
 			
 			level.playSound(player, pos, SoundEvents.UI_BUTTON_CLICK.value(), SoundSource.BLOCKS, 0.5F, 1F);

--- a/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/MinestuckEnUsLanguageProvider.java
@@ -865,7 +865,7 @@ public class MinestuckEnUsLanguageProvider extends MinestuckLanguageProvider
 		addBlock(MSBlocks.AREA_EFFECT_BLOCK, "Area Effect Block");
 		addBlockTooltip(MSBlocks.AREA_EFFECT_BLOCK, "Applies a potion effect to entities within a specified area when powered.");
 		addBlockExtra(MSBlocks.AREA_EFFECT_BLOCK, "additional_info", "- Can be toggled to apply the effect only to players\n- Can be permanently disabled\n- Area of effect changes when rotated\n- UI only accessible in creative mode\n- Right clicking with a potion bottle in creative mode sets it to that potion effect");
-		addBlockExtra(MSBlocks.AREA_EFFECT_BLOCK, AreaEffectBlock.EFFECT_CHANGE_MESSAGE, "Effect type changed to %s with the amplification strength %s.");
+		addBlockExtra(MSBlocks.AREA_EFFECT_BLOCK, AreaEffectBlock.EFFECT_CHANGE_MESSAGE, "Effect type changed to %s");
 		addBlock(MSBlocks.PLATFORM_GENERATOR, "Platform Generator");
 		addBlockTooltip(MSBlocks.PLATFORM_GENERATOR, "Creates a temporary platform when powered.");
 		addBlockExtra(MSBlocks.PLATFORM_GENERATOR, "additional_info", "- Length of area where platforms generate is proportional to power\n- Can be toggled to alternate visibility\n- Platform can be blocked by platform receptacles as well as hard or impossible to break blocks");


### PR DESCRIPTION
- Summoner Blocks and Area Effect Blocks no longer crash the game when right-clicked with a Spawn Egg and Potion respectively.
- Localized the set Entity Type and Potion Name for both blocks' status message.
- Added to changelog fix implemented by the packet cleanup, where in previous versions of the mod right-clicking a Summoner or Area Effect Block with their corresponding items wouldn't actually update their settings.