### PR TITLE
Alchemiter carved totem uv fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Signs now mineable with axe
-- Non-color data will now be preserved on dowels going through a totem lathe 
+- Non-color data will now be preserved on dowels going through a totem lathe
+- Carved totems in alchemiter model now have correct uv mapping
 
 ### Contributors for this release
 
-- Cibernet, Dweblenod, kirderf1, glubtier
+- Cibernet, Dweblenod, kirderf1, glubtier, blankMushroom
 
 ## [1.20.4-1.12.2.0] - 2024-10-06
 

--- a/src/main/resources/assets/minestuck/models/block/alchemiter_totem_pad_totem.json
+++ b/src/main/resources/assets/minestuck/models/block/alchemiter_totem_pad_totem.json
@@ -52,247 +52,269 @@
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 4, 2],
 			"to": [12, 5, 3],
 			"faces": {
-				"north": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.25, 0.4375, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.75, 0.875, 1, 0.9375], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.9375, 0.9375, 1], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [4.0, 7.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [12.0, 14.0, 16.0, 15.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 15.0, 15.0, 16.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [12, 4, 3],
 			"to": [13, 5, 7],
 			"faces": {
-				"north": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0.375, 0.4375, 0.625, 0.5], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.3125, 0.4375, 0.375, 0.5], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.9375, 0.375, 1, 0.625], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.9375, 0.6875, 1, 0.9375], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [6.0, 7.0, 10.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [5.0, 7.0, 6.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [15.0, 6.0, 16.0, 10.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [15.0, 11.0, 16.0, 15.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 4, 7],
 			"to": [12, 5, 8],
 			"faces": {
-				"east": {"uv": [0.25, 0.4375, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.625, 0.9375, 0.6875], "texture": "#totem", "tintindex": 0}
+				"east": {"uv": [4.0, 7.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 10.0, 15.0, 11.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [7, 4, 3],
 			"to": [8, 5, 7],
 			"faces": {
-				"north": {"uv": [0.3125, 0.4375, 0.375, 0.5], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.375, 0.4375, 0.625, 0.5], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.9375, 0.375, 1, 0.625], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.625, 0.6875, 0.6875, 0.9375], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [5.0, 7.0, 6.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [6.0, 7.0, 10.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [15.0, 6.0, 16.0, 10.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [10.0, 11.0, 11.0, 15.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 4, 3],
 			"to": [12, 7, 7],
 			"faces": {
-				"north": {"uv": [0.0625, 0.3125, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0.375, 0.3125, 0.625, 0.5], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.0625, 0.3125, 0.3125, 0.5], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.375, 0.3125, 0.625, 0.5], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.6875, 0.375, 0.9375, 0.625], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.6875, 0.9375, 0.9375], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [1.0, 5.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [6.0, 5.0, 10.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [1.0, 5.0, 5.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [6.0, 5.0, 10.0, 8.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [11.0, 6.0, 15.0, 10.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 11.0, 15.0, 15.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8.5, 7, 3.5],
 			"to": [11.5, 9, 6.5],
 			"faces": {
-				"north": {"uv": [0.0625, 0.1875, 0.25, 0.3125], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0.4375, 0.1875, 0.625, 0.3125], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.0625, 0.1875, 0.25, 0.3125], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.4375, 0.1875, 0.625, 0.3125], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [1.0, 3.0, 4.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [7.0, 3.0, 10.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [1.0, 3.0, 4.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [7.0, 3.0, 10.0, 5.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 9, 3],
 			"to": [12, 12, 7],
 			"faces": {
-				"north": {"uv": [0.0625, 0, 0.3125, 0.1875], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0.375, 0, 0.625, 0.1875], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.0625, 0, 0.3125, 0.1875], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.375, 0, 0.625, 0.1875], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.6875, 0.0625, 0.9375, 0.3125], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.375, 0.9375, 0.625], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [1.0, 0.0, 5.0, 3.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [6.0, 0.0, 10.0, 3.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [1.0, 0.0, 5.0, 3.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [6.0, 0.0, 10.0, 3.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [11.0, 1.0, 15.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 6.0, 15.0, 10.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 11, 2],
 			"to": [12, 12, 3],
 			"faces": {
-				"north": {"uv": [0.0625, 0, 0.3125, 0.0625], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.6875, 0, 0.9375, 0.0625], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.375, 0.9375, 0.4375], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [1.0, 0.0, 5.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [11.0, 0.0, 15.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 6.0, 15.0, 7.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [12, 11, 3],
 			"to": [13, 12, 7],
 			"faces": {
-				"north": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"east": {"uv": [0.375, 0, 0.625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.9375, 0.0625, 1, 0.3125], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.875, 0.375, 0.9375, 0.625], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"east": {"uv": [6.0, 0.0, 10.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [15.0, 1.0, 16.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [14.0, 6.0, 15.0, 10.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [8, 11, 7],
 			"to": [12, 12, 8],
 			"faces": {
-				"east": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0.0625, 0, 0.3125, 0.0625], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.6875, 0.3125, 0.9375, 0.375], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.6875, 0.5625, 0.9375, 0.625], "texture": "#totem", "tintindex": 0}
+				"east": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [1.0, 0.0, 5.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [11.0, 5.0, 15.0, 6.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [11.0, 9.0, 15.0, 10.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem",
 			"from": [7, 11, 3],
 			"to": [8, 12, 7],
 			"faces": {
-				"north": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem", "tintindex": 0},
-				"south": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"west": {"uv": [0.375, 0, 0.625, 0.0625], "texture": "#totem", "tintindex": 0},
-				"up": {"uv": [0.625, 0.0625, 0.6875, 0.3125], "texture": "#totem", "tintindex": 0},
-				"down": {"uv": [0.875, 0.375, 0.9375, 0.625], "texture": "#totem", "tintindex": 0}
+				"north": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"south": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"west": {"uv": [6.0, 0.0, 10.0, 1.0], "texture": "#totem", "tintindex": 0},
+				"up": {"uv": [10.0, 1.0, 11.0, 5.0], "texture": "#totem", "tintindex": 0},
+				"down": {"uv": [14.0, 6.0, 15.0, 10.0], "texture": "#totem", "tintindex": 0}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 4, 2],
 			"to": [12, 5, 3],
 			"faces": {
-				"north": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.25, 0.4375, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.75, 0.875, 1, 0.9375], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.9375, 0.9375, 1], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [4.0, 7.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [12.0, 14.0, 16.0, 15.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 15.0, 15.0, 16.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [12, 4, 3],
 			"to": [13, 5, 7],
 			"faces": {
-				"north": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0.375, 0.4375, 0.625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.3125, 0.4375, 0.375, 0.5], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.9375, 0.375, 1, 0.625], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.9375, 0.6875, 1, 0.9375], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [6.0, 7.0, 10.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [5.0, 7.0, 6.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [15.0, 6.0, 16.0, 10.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [15.0, 11.0, 16.0, 15.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 4, 7],
 			"to": [12, 5, 8],
 			"faces": {
-				"east": {"uv": [0.25, 0.4375, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.0625, 0.4375, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.625, 0.9375, 0.6875], "texture": "#totem2", "tintindex": 1}
+				"east": {"uv": [4.0, 7.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [1.0, 7.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 10.0, 15.0, 11.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [7, 4, 3],
 			"to": [8, 5, 7],
 			"faces": {
-				"north": {"uv": [0.3125, 0.4375, 0.375, 0.5], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0, 0.4375, 0.0625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.375, 0.4375, 0.625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.9375, 0.375, 1, 0.625], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.625, 0.6875, 0.6875, 0.9375], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [5.0, 7.0, 6.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [0.0, 7.0, 1.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [6.0, 7.0, 10.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [15.0, 6.0, 16.0, 10.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [10.0, 11.0, 11.0, 15.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 4, 3],
 			"to": [12, 7, 7],
 			"faces": {
-				"north": {"uv": [0.0625, 0.3125, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0.375, 0.3125, 0.625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.0625, 0.3125, 0.3125, 0.5], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.375, 0.3125, 0.625, 0.5], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.6875, 0.375, 0.9375, 0.625], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.6875, 0.9375, 0.9375], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [1.0, 5.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [6.0, 5.0, 10.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [1.0, 5.0, 5.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [6.0, 5.0, 10.0, 8.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [11.0, 6.0, 15.0, 10.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 11.0, 15.0, 15.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8.5, 7, 3.5],
 			"to": [11.5, 9, 6.5],
 			"faces": {
-				"north": {"uv": [0.0625, 0.1875, 0.25, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0.4375, 0.1875, 0.625, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.0625, 0.1875, 0.25, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.4375, 0.1875, 0.625, 0.3125], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [1.0, 3.0, 4.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [7.0, 3.0, 10.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [1.0, 3.0, 4.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [7.0, 3.0, 10.0, 5.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 9, 3],
 			"to": [12, 12, 7],
 			"faces": {
-				"north": {"uv": [0.0625, 0, 0.3125, 0.1875], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0.375, 0, 0.625, 0.1875], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.0625, 0, 0.3125, 0.1875], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.375, 0, 0.625, 0.1875], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.6875, 0.0625, 0.9375, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.375, 0.9375, 0.625], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [1.0, 0.0, 5.0, 3.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [6.0, 0.0, 10.0, 3.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [1.0, 0.0, 5.0, 3.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [6.0, 0.0, 10.0, 3.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [11.0, 1.0, 15.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 6.0, 15.0, 10.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 11, 2],
 			"to": [12, 12, 3],
 			"faces": {
-				"north": {"uv": [0.0625, 0, 0.3125, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.6875, 0, 0.9375, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.375, 0.9375, 0.4375], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [1.0, 0.0, 5.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [11.0, 0.0, 15.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 6.0, 15.0, 7.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [12, 11, 3],
 			"to": [13, 12, 7],
 			"faces": {
-				"north": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"east": {"uv": [0.375, 0, 0.625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.9375, 0.0625, 1, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.875, 0.375, 0.9375, 0.625], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"east": {"uv": [6.0, 0.0, 10.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [15.0, 1.0, 16.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [14.0, 6.0, 15.0, 10.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [8, 11, 7],
 			"to": [12, 12, 8],
 			"faces": {
-				"east": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0.0625, 0, 0.3125, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.6875, 0.3125, 0.9375, 0.375], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.6875, 0.5625, 0.9375, 0.625], "texture": "#totem2", "tintindex": 1}
+				"east": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [1.0, 0.0, 5.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [11.0, 5.0, 15.0, 6.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [11.0, 9.0, 15.0, 10.0], "texture": "#totem2", "tintindex": 1}
 			}
 		},
 		{
+			"name": "totem2",
 			"from": [7, 11, 3],
 			"to": [8, 12, 7],
 			"faces": {
-				"north": {"uv": [0.3125, 0, 0.375, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"south": {"uv": [0, 0, 0.0625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"west": {"uv": [0.375, 0, 0.625, 0.0625], "texture": "#totem2", "tintindex": 1},
-				"up": {"uv": [0.625, 0.0625, 0.6875, 0.3125], "texture": "#totem2", "tintindex": 1},
-				"down": {"uv": [0.875, 0.375, 0.9375, 0.625], "texture": "#totem2", "tintindex": 1}
+				"north": {"uv": [5.0, 0.0, 6.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"south": {"uv": [0.0, 0.0, 1.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"west": {"uv": [6.0, 0.0, 10.0, 1.0], "texture": "#totem2", "tintindex": 1},
+				"up": {"uv": [10.0, 1.0, 11.0, 5.0], "texture": "#totem2", "tintindex": 1},
+				"down": {"uv": [14.0, 6.0, 15.0, 10.0], "texture": "#totem2", "tintindex": 1}
 			}
 		}
 	],


### PR DESCRIPTION
Since the Geckolib remodel update, the carved totems/dowels in the alchemiter showed as a single color. blankMushroom identified the source of the problem as a misaligned uv mapping and created a fixed version.