### PR TITLE
Fix farmine not working as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Stack and Queue modi have more distinct recipes
+- Farmine break blacklist is now controlled by the `minestuck:farmine_break_blacklist` block tag, instead of being hardcoded
 
 ### Fixed
 
 - Fix some items having 0 grist cost
 - Fix weapons having the wrong durability
+- Fix farmine only mining a 3x3x3 cube around the block mined
 
 ### Removed
 

--- a/src/main/generated/resources/data/minestuck/tags/block/farmine_break_blacklist.json
+++ b/src/main/generated/resources/data/minestuck/tags/block/farmine_break_blacklist.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:obsidian"
+  ]
+}

--- a/src/main/java/com/mraof/minestuck/data/tag/MinestuckBlockTagsProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/tag/MinestuckBlockTagsProvider.java
@@ -371,6 +371,7 @@ public final class MinestuckBlockTagsProvider extends BlockTagsProvider
 		tag(PUSHABLE_BLOCK_REPLACEABLE).addTags(SAPLINGS, FLOWERS);
 		tag(PETRIFIED_FLORA_PLACEABLE).addTags(Tags.Blocks.STONES, Tags.Blocks.COBBLESTONES, Tags.Blocks.GRAVELS);
 		tag(EDITMODE_BREAK_BLACKLIST).addTags(BlockTags.PORTALS);
+		tag(FARMINE_BREAK_BLACKLIST).add(Blocks.OBSIDIAN);
 	}
 	
 	@Override

--- a/src/main/java/com/mraof/minestuck/item/weapon/WeaponItem.java
+++ b/src/main/java/com/mraof/minestuck/item/weapon/WeaponItem.java
@@ -194,7 +194,7 @@ public class WeaponItem extends TieredItem
 		
 		public Builder set(DestroyBlockEffect effect)
 		{
-			if(rightClickBlockEffect != null)
+			if(destroyBlockEffect != null)
 				throw new IllegalStateException("Destroy block effect has already been set");
 			destroyBlockEffect = effect;
 			return this;

--- a/src/main/java/com/mraof/minestuck/util/MSTags.java
+++ b/src/main/java/com/mraof/minestuck/util/MSTags.java
@@ -74,6 +74,7 @@ public class MSTags
 		public static final TagKey<Block> PUSHABLE_BLOCK_REPLACEABLE = tag("portable_block_replaceable");
 		public static final TagKey<Block> PETRIFIED_FLORA_PLACEABLE = tag("petrified_flora_placeable");
 		public static final TagKey<Block> EDITMODE_BREAK_BLACKLIST = tag("editmode_break_blacklist");
+		public static final TagKey<Block> FARMINE_BREAK_BLACKLIST = tag("farmine_break_blacklist");
 		
 		public static final TagKey<Block> MINEABLE_WITH_SICKLE = tag("mineable_with_sickle");
 		public static final TagKey<Block> MINEABLE_WITH_SCYTHE = tag("mineable_with_scythe");


### PR DESCRIPTION
Farmine was bugged and would only mine a 3x3x3 cube of the same block, ignoring radius and block limit.

The added tag, `minestuck:farmine_break_blacklist`, replaces the hardcoded list of forbidden blocks. It only contains obsidian by default, and limits breaking to 3x3x3.

This solves the issue, buffing all farmine weapons, except for the Coppice Crusher.

I've also fixed an error in WeaponItem where setting a DestroyBlockEffect would not work when a RightClickBlockEffect is set.

Closes #672