### PR TITLE
Draw skybox veil meteors in one rendering batch for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add back song description for cassette items
 - Fix hover area for some tooltip in the echeladder screen
 - Removed Refined Storage compatibility feature that was not compatible with Refined Storage 2
+- Improve land skybox performance
 
 ### Removed
 


### PR DESCRIPTION
Using drawSprite() will draw it one sprite at a time, which means one rendering call for each of the 1500 meteors. The new solution (similar to what is used in other places of skybox rendering) is to add all meteors to the same buffer builder and then render all of them in one call.