### PR TITLE
Set teleport pos in the compound tag before loading new entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add back song description for cassette items
 - Fix hover area for some tooltip in the echeladder screen
 - Removed Refined Storage compatibility feature that was not compatible with Refined Storage 2
+- Fix entry breaking certain Create contraptions
 - Improve land skybox performance
 
 ### Removed

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
         // maven that contains infiniverse
         url "https://commoble.net/maven/"
     }
+    maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+    maven { url = "https://maven.ithundxr.dev/snapshots" } // Registrate
 }
 
 version = project.getProperty('mc_ms_version')
@@ -82,6 +84,12 @@ dependencies {
 
     implementation "software.bernie.geckolib:geckolib-${mc_gecko_version}"
     implementation "net.commoble.infiniverse:${infiniverse_branch}:${infiniverse_version}"
+
+    // Add the Create mod to runtime to help test mod interactions
+    runtimeOnly("com.simibubi.create:create-${mc_version}:${create_version}:slim") { transitive = false }
+    runtimeOnly("net.createmod.ponder:Ponder-NeoForge-${mc_version}:${ponder_version}")
+    runtimeOnly("dev.engine-room.flywheel:flywheel-neoforge-${mc_version}:${flywheel_version}")
+    runtimeOnly("com.tterrag.registrate:Registrate:${registrate_version}")
 }
 
 sourceSets.main.resources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,23 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 org.gradle.daemon=false
 
-mc_version=1.21
+mc_version=1.21.1
 
 mc_ms_version=1.21.1-1.13.0.1
 
-neo_version=21.1.80
+neo_version=21.1.152
 
 neogradle.subsystems.parchment.minecraftVersion=1.21
 neogradle.subsystems.parchment.mappingsVersion=2024.07.28
 
-mc_jei_version=19.8.2.99
+mc_jei_version=19.21.2.313
 
 mc_gecko_version=neoforge-1.21.1:4.7
 
 infiniverse_branch=infiniverse-1.21
 infiniverse_version=2.0.1.0
+
+create_version=6.0.6-98
+ponder_version=1.0.59
+flywheel_version=1.0.4
+registrate_version = MC1.21-1.3.0+62

--- a/src/main/java/com/mraof/minestuck/util/Teleport.java
+++ b/src/main/java/com/mraof/minestuck/util/Teleport.java
@@ -1,6 +1,10 @@
 package com.mraof.minestuck.util;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.DoubleTag;
+import net.minecraft.nbt.FloatTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
@@ -68,9 +72,24 @@ public class Teleport	//TODO there might still be things that vanilla does that 
 				if (entity == null)
 					return null;
 				
-				entity.restoreFrom(oldEntity);
-				entity.moveTo(x, y, z, yaw, pitch);
-				entity.setYHeadRot(yaw);
+				CompoundTag compoundtag = oldEntity.saveWithoutId(new CompoundTag());
+				compoundtag.remove("Dimension");
+				
+				// Update position in compound tag before load() because some entities (such as ControlledContraptionEntity from Create)
+				// depend on the new position during load()
+				ListTag posTag = new ListTag();
+				posTag.add(DoubleTag.valueOf(x));
+				posTag.add(DoubleTag.valueOf(y));
+				posTag.add(DoubleTag.valueOf(z));
+				compoundtag.put("Pos", posTag);
+				
+				ListTag rotationTag = new ListTag();
+				rotationTag.add(FloatTag.valueOf(yaw));
+				rotationTag.add(FloatTag.valueOf(pitch));
+				compoundtag.put("Rotation", rotationTag);
+				
+				entity.load(compoundtag);
+				
 				oldEntity.remove(Entity.RemovalReason.CHANGED_DIMENSION);
 				level.addDuringTeleport(entity);
 			}


### PR DESCRIPTION
This fixes a compatibility issue with Create where certain contraptions (such as windmills) would consistently break during entry.

The fix is to ensure that the new position is stored in the nbt data for the new entity before invoking `entity.load()`. By doing this, the entity is able to load the correct position for the corresponding contraption block.

Note that this just fixes the most obvious issue. Machines can still break in particular ways if for example only the block or only the entity is transferred during entry. But these type of edge cases are not the focus of this PR.