### PR TITLE
Fix 3 alchemy recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Glowing Mushroom Vines requiring itself for alchemizing
+- Fix missing Bucket of Glimmering Water and Magmatic Igneous Stone grist cost
+
+### Contributors for this release
+
+- medsal15
+
 ## [1.21.1-1.13.1.1] - 2025-09-14
 
 ### Added

--- a/src/main/generated/resources/data/minestuck/recipe/combinations/glowing_mushroom_vines.json
+++ b/src/main/generated/resources/data/minestuck/recipe/combinations/glowing_mushroom_vines.json
@@ -1,7 +1,7 @@
 {
   "type": "minestuck:combination",
   "input1": {
-    "item": "minestuck:glowing_mushroom_vines"
+    "item": "minestuck:glowing_mushroom"
   },
   "input2": {
     "item": "minecraft:vine"

--- a/src/main/generated/resources/data/minestuck/recipe/grist_costs/light_water_bucket.json
+++ b/src/main/generated/resources/data/minestuck/recipe/grist_costs/light_water_bucket.json
@@ -1,0 +1,10 @@
+{
+  "type": "minestuck:container_grist_cost",
+  "grist_cost": {
+    "minestuck:chalk": 8,
+    "minestuck:cobalt": 4
+  },
+  "ingredient": {
+    "item": "minestuck:light_water_bucket"
+  }
+}

--- a/src/main/generated/resources/data/minestuck/recipe/grist_costs/magmatic_igneous_stone.json
+++ b/src/main/generated/resources/data/minestuck/recipe/grist_costs/magmatic_igneous_stone.json
@@ -1,0 +1,10 @@
+{
+  "type": "minestuck:source_grist_cost",
+  "grist_cost": {},
+  "ingredient": {
+    "item": "minestuck:magmatic_igneous_stone"
+  },
+  "sources": [
+    "minestuck:magmatic_polished_igneous_bricks"
+  ]
+}

--- a/src/main/java/com/mraof/minestuck/data/recipe/MinestuckCombinationsProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/recipe/MinestuckCombinationsProvider.java
@@ -775,7 +775,7 @@ public final class MinestuckCombinationsProvider
 		CombinationRecipeBuilder.of(MSBlocks.VINE_LOG).input(Items.OAK_LOG).and().input(Items.VINE).build(consumer);
 		CombinationRecipeBuilder.of(MSBlocks.FLOWERY_VINE_LOG).input(MSBlocks.VINE_LOG).or().input(ItemTags.SMALL_FLOWERS).build(consumer);
 		CombinationRecipeBuilder.of(MSBlocks.GLOWING_MUSHROOM).input(Items.BROWN_MUSHROOM).or().input(Items.GLOWSTONE_DUST).build(consumer);
-		CombinationRecipeBuilder.of(MSBlocks.GLOWING_MUSHROOM_VINES).input(MSItems.GLOWING_MUSHROOM_VINES).and().input(Items.VINE).build(consumer);
+		CombinationRecipeBuilder.of(MSBlocks.GLOWING_MUSHROOM_VINES).input(MSItems.GLOWING_MUSHROOM).and().input(Items.VINE).build(consumer);
 		CombinationRecipeBuilder.of(MSBlocks.GLOWING_LOG).input(ItemTags.LOGS).or().input(MSBlocks.GLOWING_MUSHROOM).build(consumer);
 		CombinationRecipeBuilder.of(MSBlocks.GLOWING_PLANKS).input(ItemTags.PLANKS).or().input(MSBlocks.GLOWING_MUSHROOM).build(consumer);
 		CombinationRecipeBuilder.of(MSBlocks.GLOWY_GOOP).input(Items.SLIME_BLOCK).or().input(MSBlocks.GLOWING_MUSHROOM).build(consumer);

--- a/src/main/java/com/mraof/minestuck/data/recipe/MinestuckGristCostsProvider.java
+++ b/src/main/java/com/mraof/minestuck/data/recipe/MinestuckGristCostsProvider.java
@@ -828,6 +828,7 @@ public final class MinestuckGristCostsProvider
 		GristCostRecipeBuilder.of(MSBlocks.CAST_IRON.get()).grist(BUILD, 3).grist(RUST, 2).build(recipeSaver);
 		GristCostRecipeBuilder.of(MSBlocks.STEEL_BEAM.get()).grist(BUILD, 2).grist(RUST, 3).build(recipeSaver);
 		GristCostRecipeBuilder.of(MSBlocks.BLACK_SAND.get()).grist(BUILD, 2).grist(SULFUR, 1).build(recipeSaver);
+		SourceGristCostBuilder.of(MSBlocks.MAGMATIC_IGNEOUS_STONE.get()).source(MSBlocks.MAGMATIC_POLISHED_IGNEOUS_BRICKS.asItem()).build(recipeSaver);
 		GristCostRecipeBuilder.of(MSBlocks.IGNEOUS_STONE.get()).grist(BUILD, 2).grist(TAR, 1).build(recipeSaver);
 		GristCostRecipeBuilder.of(MSBlocks.IGNEOUS_SPIKE.get()).grist(BUILD, 1).grist(TAR, 1).build(recipeSaver);
 		GristCostRecipeBuilder.of(MSBlocks.PUMICE_STONE.get()).grist(BUILD, 2).grist(TAR, 1).build(recipeSaver);
@@ -927,6 +928,7 @@ public final class MinestuckGristCostsProvider
 		ContainerGristCostBuilder.of(MSItems.BRAIN_JUICE_BUCKET.get()).grist(AMETHYST, 8).grist(CHALK, 8).build(recipeSaver);
 		ContainerGristCostBuilder.of(MSItems.WATER_COLORS_BUCKET.get()).grist(AMETHYST, 4).grist(CHALK, 4).grist(GARNET, 4).grist(AMBER, 4).build(recipeSaver);
 		ContainerGristCostBuilder.of(MSItems.ENDER_BUCKET.get()).grist(MERCURY, 8).grist(URANIUM, 8).build(recipeSaver);
+		ContainerGristCostBuilder.of(MSItems.LIGHT_WATER_BUCKET.get()).grist(COBALT, 4).grist(CHALK, 8).build(recipeSaver);
 		ContainerGristCostBuilder.of(MSItems.OBSIDIAN_BUCKET.get()).grist(BUILD, 4).grist(COBALT, 8).grist(TAR, 16).build(recipeSaver);
 		ContainerGristCostBuilder.of(MSItems.CAULK_BUCKET.get()).grist(CAULK, 16).build(recipeSaver);
 		ContainerGristCostBuilder.of(MSItems.MOLTEN_AMBER_BUCKET.get()).grist(AMBER, 16).build(recipeSaver);


### PR DESCRIPTION
Glowing Mushroom Vines combination recipe now correctly uses Glowing Mushroom
Despite having combination recipes, Bucket of Glimmering Water and Magmatic Igneous Stone were missing grist costs

Closes #688