### PR TITLE
Fix non-minestuck program types sharing the same name namespace

### DIFF
--- a/src/main/java/com/mraof/minestuck/computer/ProgramType.java
+++ b/src/main/java/com/mraof/minestuck/computer/ProgramType.java
@@ -40,7 +40,7 @@ public final class ProgramType<D extends ProgramType.Data>
 	public MutableComponent name()
 	{
 		ResourceLocation key = ProgramTypes.REGISTRY.getKey(this);
-		return key != null ? Component.translatable("minestuck.program." + key.getPath()) : Component.literal("Unknown Program");
+		return key != null ? Component.translatable(key.getNamespace() + ".program." + key.getPath()) : Component.literal("Unknown Program");
 	}
 	
 	public interface Data


### PR DESCRIPTION
All program types are have the same first section of the key, which should be the namespace/modid, set to minestuck. This PR solves that by using the program type's namespace