### PR TITLE
Fix sylladex voiding items when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Fixed server tick crash related to kernelsprite dialogue
 - Fixed certain block not being in their relevant tag
+- Fixed items sometimes disappearing when closing the sylladex
 
 ### Contributors for this release
 

--- a/src/main/java/com/mraof/minestuck/client/gui/playerStats/PlayerStatsContainerScreen.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/playerStats/PlayerStatsContainerScreen.java
@@ -150,6 +150,8 @@ public abstract class PlayerStatsContainerScreen<T extends AbstractContainerMenu
 	{
 		if(MSKeyHandler.statKey.isActiveAndMatches(InputConstants.getKey(keyCode, scanCode)))
 		{
+			if(mode)
+				this.onClose();
 			minecraft.setScreen(null);
 			return true;
 		}


### PR DESCRIPTION
This only happened when using the minestuck menu keybind.

The mode check can be safely removed, but may cause the editmode inventory to clutter. I still tested to check that no item is dropped.